### PR TITLE
heres automatic architecture detection

### DIFF
--- a/archi
+++ b/archi
@@ -1072,3 +1072,4 @@ while :; do
 		x|X) exit 0
 	esac
 done
+


### PR DESCRIPTION
tmpstore=$(grep -i "ro.product.cpu.abi" $ACTIVE_PROJECT/system/build.prop | head -n 1 | cut -d'=' -f2)
if [[ $tmpstore = "armeabi-v7a" ]] 
then
    arch=ARM
fi
if [[ $tmpstore = "armeabi" ]] 
then
    arch=ARM
fi
if [[ $tmpstore = "x86" ]] 
then
    arch=X86
fi

add it as you wish!
