### PR TITLE
Fix kernel init.d support

### DIFF
--- a/archi
+++ b/archi
@@ -797,11 +797,9 @@ KERNEL_ABORT() {
 
 # Adds kernel's Init.d
 INITD() {
-	KERNEL_EXTRACT
 	if [[ -f "$ACTIVE_PROJECT/kernel/ramdisk/init.rc" ]]; then
 		sed -i -e '0,/class_start /s//start sysinit\n\n    class_start /' "$ACTIVE_PROJECT/kernel/ramdisk/init.rc"
 		sed -i -e 's/service media /service sysinit \/system\/bin\/logwrapper \/system\/xbin\/busybox run-parts \/system\/etc\/init.d\n    disabled\n    oneshot\n\nservice media /' "$ACTIVE_PROJECT/kernel/ramdisk/init.rc"
-		KERNEL_REPACK
 		cp -R files/initd/system/* "$ACTIVE_PROJECT/system/"
 		UPDATER_SCRIPT_ADD "files/initd/updater-scripts"
 	else


### PR DESCRIPTION
The active project variable was missing, so it couldn't find the folder ;). I tested it, and it works in my kernel for M8!

Can there be an option to leave the ramdisk unpacked after adding this, or at least a note to indicate to do this last, since it'll repack it?

Thanks again for the fantastic kitchen! Now I just have to figure out why I have no bootanimation when using it . . .
